### PR TITLE
Drop HHVM and use the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
+sudo: false
 
-php:
-  - '7.0'
-  - '7.1'
-  - hhvm
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2


### PR DESCRIPTION
HHVM LTS 3.24 is the last version to support PHP 5 compatibility
third paragraph states "HHVM will not aim to target PHP7" and further down "We do not intend to be the runtime of choice for folks with pure PHP7 code." (just HACK)
https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html

add PHP 7.2
Uses build matrix
uses sudo false for faster container based testing when sudo is not used